### PR TITLE
feat: auto-skip actions/setup-node on Alpine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,5 @@
 * Reads node version file (.node-version) from project root
 * Only saves pnpm cache on the main branch
 * Restores pnpm cache on PR
-* Auto-detects Alpine Linux containers and skips `actions/setup-node`
-  (which only ships glibc binaries) so the container's musl Node is used.
-  Override with `install-node: true | false`.
+* Skips `actions/setup-node` on Alpine Linux (which only ships glibc
+  binaries) and uses the container's musl Node instead.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 * Reads node version file (.node-version) from project root
 * Only saves pnpm cache on the main branch
 * Restores pnpm cache on PR
+* Auto-detects Alpine Linux containers and skips `actions/setup-node`
+  (which only ships glibc binaries) so the container's musl Node is used.
+  Override with `install-node: true | false`.

--- a/action.yml
+++ b/action.yml
@@ -21,14 +21,11 @@ inputs:
     required: false
     description: 'Optional CPU architecture for pnpm supportedArchitectures configuration (e.g., x64, arm64).'
 
-  install-node:
-    required: false
-    default: 'auto'
-    description: 'Whether to install Node.js via actions/setup-node. "auto" (default) skips installation on Alpine Linux, where the GitHub toolcache only ships glibc Node binaries that cannot run on musl, and uses the container/system Node instead. "true" forces install. "false" skips.'
-
 runs:
   using: composite
   steps:
+    # actions/setup-node only ships glibc Node binaries; on Alpine those can't
+    # run, so use the container's musl Node instead.
     - name: Detect Alpine Linux
       id: detect
       if: runner.os == 'Linux'
@@ -41,7 +38,7 @@ runs:
     - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-      if: ${{ inputs.install-node == 'true' || (inputs.install-node == 'auto' && steps.detect.outputs.is-alpine != 'true') }}
+      if: steps.detect.outputs.is-alpine != 'true'
       with:
         node-version-file: .node-version
         architecture: ${{ inputs.architecture }}

--- a/action.yml
+++ b/action.yml
@@ -31,12 +31,11 @@ runs:
   steps:
     - name: Detect Alpine Linux
       id: detect
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         if [ -f /etc/alpine-release ]; then
           echo "is-alpine=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "is-alpine=false" >> "$GITHUB_OUTPUT"
         fi
 
     - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0

--- a/action.yml
+++ b/action.yml
@@ -21,12 +21,28 @@ inputs:
     required: false
     description: 'Optional CPU architecture for pnpm supportedArchitectures configuration (e.g., x64, arm64).'
 
+  install-node:
+    required: false
+    default: 'auto'
+    description: 'Whether to install Node.js via actions/setup-node. "auto" (default) skips installation on Alpine Linux, where the GitHub toolcache only ships glibc Node binaries that cannot run on musl, and uses the container/system Node instead. "true" forces install. "false" skips.'
+
 runs:
   using: composite
   steps:
+    - name: Detect Alpine Linux
+      id: detect
+      shell: bash
+      run: |
+        if [ -f /etc/alpine-release ]; then
+          echo "is-alpine=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "is-alpine=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      if: ${{ inputs.install-node == 'true' || (inputs.install-node == 'auto' && steps.detect.outputs.is-alpine != 'true') }}
       with:
         node-version-file: .node-version
         architecture: ${{ inputs.architecture }}


### PR DESCRIPTION
## Summary

\`actions/setup-node\` only ships glibc Node binaries via the GitHub toolcache, so when this action runs inside an Alpine container (e.g. \`node:22-alpine\`) it installs a glibc binary into PATH that shadows the container's musl-native Node. Subprocesses that spawn \`node\` then fail with ENOENT — Linux returns ENOENT when the dynamic linker (\`/lib64/ld-linux-x86-64.so.2\`) is missing, which it is on Alpine.

Repro from voidzero-dev/vite-task: https://github.com/voidzero-dev/vite-task/actions/runs/25104547071/job/73562308469?pr=367 — fspy's \`node_fs\` tests fail with \`Error: underlying os error: No such file or directory (os error 2)\` after \`oxc-project/setup-node\` runs in a \`node:22-alpine3.21\` container.

## Change

Add an \`install-node\` input defaulting to \`auto\`. A new detection step checks \`/etc/alpine-release\`; on Alpine, \`auto\` skips \`actions/setup-node\` and the workflow uses the container's existing musl Node. Users can force-install with \`true\` or opt out entirely with \`false\`. Existing non-Alpine users see no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)