### PR TITLE
Stop the pnpm store cache from growing without bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Setup Node and pnpm
 
 * Reads node version file (.node-version) from project root
-* Only saves pnpm cache on the main branch, and only when the current lockfile
-  has no cache entry yet
-* main restores on an exact lockfile match only, so a save is never the union
-  of an older store and the new install — the store stays the size of the
-  current lockfile instead of accumulating every package version ever built
-* Restores pnpm cache on PR, falling back to the newest store main saved
+* Only saves pnpm cache on the default branch, and only when the current
+  lockfile has no cache entry yet
+* The default branch restores on an exact lockfile match only, so a save is
+  never the union of an older store and the new install — the store stays the
+  size of the current lockfile instead of accumulating every package version
+  ever built
+* Restores pnpm cache on PR, falling back to the newest store the default
+  branch saved
 * Skips `actions/setup-node` on Alpine Linux (which only ships glibc
   binaries) and uses the container's musl Node instead.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Setup Node and pnpm
 
 * Reads node version file (.node-version) from project root
-* Only saves pnpm cache on the main branch
-* Restores pnpm cache on PR
+* Only saves pnpm cache on the main branch, and only on an exact lockfile
+  match, so the store stays the size of the current lockfile instead of
+  accumulating every package version ever built
+* Restores pnpm cache on PR, falling back to the newest store main saved
 * Skips `actions/setup-node` on Alpine Linux (which only ships glibc
   binaries) and uses the container's musl Node instead.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Setup Node and pnpm
 
 * Reads node version file (.node-version) from project root
-* Only saves pnpm cache on the main branch, and only on an exact lockfile
-  match, so the store stays the size of the current lockfile instead of
-  accumulating every package version ever built
+* Only saves pnpm cache on the main branch, and only when the current lockfile
+  has no cache entry yet
+* main restores on an exact lockfile match only, so a save is never the union
+  of an older store and the new install — the store stays the size of the
+  current lockfile instead of accumulating every package version ever built
 * Restores pnpm cache on PR, falling back to the newest store main saved
 * Skips `actions/setup-node` on Alpine Linux (which only ships glibc
   binaries) and uses the container's musl Node instead.

--- a/action.yml
+++ b/action.yml
@@ -90,16 +90,16 @@ runs:
     # failure in the calling job.
     #
     # `ref_name == 'main'` is also true under pull_request_target, which runs
-    # with GITHUB_REF pointing at the default branch. That is not a poisoning
-    # vector: only push, workflow_dispatch, repository_dispatch, delete,
-    # registry_package, page_build and schedule may create or overwrite caches
-    # in the default branch's scope, so a pull_request_target run's save is
-    # rejected by the cache service (and continue-on-error keeps that from
-    # failing the job). Fork pull_request runs can only write their own merge
-    # ref scope, which no other PR and no branch can restore.
+    # with GITHUB_REF pointing at the base branch rather than the PR head, so
+    # its cache writes land in the default branch's scope. A caller that checks
+    # out the PR head under pull_request_target would then install from a fork's
+    # lockfile and publish that store as main's — which every later run picks up
+    # via the prefix fallback. Hence the event guard below. Fork pull_request
+    # runs need no guard: they can only write their own merge ref scope, which
+    # no other PR and no branch can restore.
     - name: Save pnpm cache on main
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: ${{ github.ref_name == 'main' && steps.cache.outputs.cache-hit != 'true' }}
+      if: ${{ github.ref_name == 'main' && github.event_name != 'pull_request_target' && steps.cache.outputs.cache-hit != 'true' }}
       continue-on-error: true
       with:
         path: ${{ steps.store.outputs.STORE_PATH }}

--- a/action.yml
+++ b/action.yml
@@ -57,24 +57,24 @@ runs:
     # STATUS_STACK_BUFFER_OVERRUN (exit code 0xC0000409), dying with no error
     # message and failing the job. Caching is a non-essential optimization, so
     # never let it fail the build. See actions/cache#1754.
-    - name: Save and restore pnpm cache on main
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: ${{ github.ref_name == 'main' }}
+    #
+    # main restores on an exact lockfile match only. Falling back to the
+    # ${{ runner.os }}-pnpm-store- prefix here would make each save the union of
+    # the old store and the new install, so the store would accumulate every
+    # package version ever built and grow without bound. PRs never save, so
+    # they do take the prefix fallback and reuse whatever main last stored.
+    - name: Restore pnpm cache
+      id: cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       continue-on-error: true
       with:
         path: ${{ steps.store.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
-
-    - name: Restore pnpm cache on PR
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: ${{ github.ref_name != 'main' }}
-      continue-on-error: true
-      with:
-        path: ${{ steps.store.outputs.STORE_PATH }}
-        key: |
-          ${{ runner.os }}-pnpm-store-
+        # Written as `!= 'main' && <prefix> || ''` rather than the more natural
+        # `== 'main' && '' || <prefix>`: in a GitHub expression `a && b || c`
+        # falls through to c whenever b is falsy, and '' is falsy, so the
+        # natural spelling would hand main the prefix in both branches.
+        restore-keys: ${{ github.ref_name != 'main' && format('{0}-pnpm-store-', runner.os) || '' }}
 
     - name: Set CPU architecture for pnpm
       if: ${{ inputs.cpu }}
@@ -85,3 +85,22 @@ runs:
 
     - run: pnpm install --frozen-lockfile --ignore-scripts
       shell: bash
+
+    # Saved here rather than as a post-job step so the store survives a later
+    # failure in the calling job.
+    #
+    # `ref_name == 'main'` is also true under pull_request_target, which runs
+    # with GITHUB_REF pointing at the default branch. That is not a poisoning
+    # vector: only push, workflow_dispatch, repository_dispatch, delete,
+    # registry_package, page_build and schedule may create or overwrite caches
+    # in the default branch's scope, so a pull_request_target run's save is
+    # rejected by the cache service (and continue-on-error keeps that from
+    # failing the job). Fork pull_request runs can only write their own merge
+    # ref scope, which no other PR and no branch can restore.
+    - name: Save pnpm cache on main
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      if: ${{ github.ref_name == 'main' && steps.cache.outputs.cache-hit != 'true' }}
+      continue-on-error: true
+      with:
+        path: ${{ steps.store.outputs.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}

--- a/action.yml
+++ b/action.yml
@@ -53,16 +53,29 @@ runs:
       run: |
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
+    # Which branch may write the cache. Resolved once here rather than compared
+    # against a hardcoded 'main', so repos on master/trunk get a cache too.
+    #
+    # github.event.repository is absent from a few event payloads; fall back to
+    # 'main' rather than to an empty string, which would match no branch and
+    # silently disable saving everywhere.
+    - name: Resolve default branch
+      id: default_branch
+      shell: bash
+      run: echo "name=${DEFAULT_BRANCH:-main}" >> "$GITHUB_OUTPUT"
+      env:
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
     # actions/cache (Node) intermittently hard-crashes on Windows runners with
     # STATUS_STACK_BUFFER_OVERRUN (exit code 0xC0000409), dying with no error
     # message and failing the job. Caching is a non-essential optimization, so
     # never let it fail the build. See actions/cache#1754.
     #
-    # main restores on an exact lockfile match only. Falling back to the
-    # <os>-<arch>-<cpu>-pnpm-store- prefix here would make each save the union
-    # of the old store and the new install, so the store would accumulate every
-    # package version ever built and grow without bound. PRs never save, so
-    # they do take the prefix fallback and reuse whatever main last stored.
+    # The default branch restores on an exact lockfile match only. Falling back
+    # to the <os>-<arch>-<cpu>-pnpm-store- prefix here would make each save the
+    # union of the old store and the new install, so the store would accumulate
+    # every package version ever built and grow without bound. PRs never save,
+    # so they do take the prefix fallback and reuse the newest store saved.
     #
     # The key covers runner.arch and inputs.cpu as well as runner.os because
     # the store's contents are architecture-specific: platform-specific
@@ -77,11 +90,12 @@ runs:
       with:
         path: ${{ steps.store.outputs.STORE_PATH }}
         key: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.cpu || 'default' }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-        # Written as `!= 'main' && <prefix> || ''` rather than the more natural
-        # `== 'main' && '' || <prefix>`: in a GitHub expression `a && b || c`
-        # falls through to c whenever b is falsy, and '' is falsy, so the
-        # natural spelling would hand main the prefix in both branches.
-        restore-keys: ${{ github.ref_name != 'main' && format('{0}-{1}-{2}-pnpm-store-', runner.os, runner.arch, inputs.cpu || 'default') || '' }}
+        # Written as `!= <default> && <prefix> || ''` rather than the more
+        # natural `== <default> && '' || <prefix>`: in a GitHub expression
+        # `a && b || c` falls through to c whenever b is falsy, and '' is
+        # falsy, so the natural spelling would hand the default branch the
+        # prefix in both branches.
+        restore-keys: ${{ github.ref_name != steps.default_branch.outputs.name && format('{0}-{1}-{2}-pnpm-store-', runner.os, runner.arch, inputs.cpu || 'default') || '' }}
 
     - name: Set CPU architecture for pnpm
       if: ${{ inputs.cpu }}
@@ -96,17 +110,18 @@ runs:
     # Saved here rather than as a post-job step so the store survives a later
     # failure in the calling job.
     #
-    # `ref_name == 'main'` is also true under pull_request_target, which runs
-    # with GITHUB_REF pointing at the base branch rather than the PR head, so
-    # its cache writes land in the default branch's scope. A caller that checks
-    # out the PR head under pull_request_target would then install from a fork's
-    # lockfile and publish that store as main's — which every later run picks up
-    # via the prefix fallback. Hence the event guard below. Fork pull_request
-    # runs need no guard: they can only write their own merge ref scope, which
-    # no other PR and no branch can restore.
-    - name: Save pnpm cache on main
+    # The default-branch check below is also satisfied under
+    # pull_request_target, which runs with GITHUB_REF pointing at the base
+    # branch rather than the PR head, so its cache writes land in the default
+    # branch's scope. A caller that checks out the PR head under
+    # pull_request_target would then install from a fork's lockfile and publish
+    # that store as the default branch's — which every later run picks up via
+    # the prefix fallback. Hence the event guard below. Fork pull_request runs
+    # need no guard: they can only write their own merge ref scope, which no
+    # other PR and no branch can restore.
+    - name: Save pnpm cache on the default branch
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      if: ${{ github.ref_name == 'main' && github.event_name != 'pull_request_target' && steps.cache.outputs.cache-hit != 'true' }}
+      if: ${{ github.ref_name == steps.default_branch.outputs.name && github.event_name != 'pull_request_target' && steps.cache.outputs.cache-hit != 'true' }}
       continue-on-error: true
       with:
         path: ${{ steps.store.outputs.STORE_PATH }}

--- a/action.yml
+++ b/action.yml
@@ -59,22 +59,29 @@ runs:
     # never let it fail the build. See actions/cache#1754.
     #
     # main restores on an exact lockfile match only. Falling back to the
-    # ${{ runner.os }}-pnpm-store- prefix here would make each save the union of
-    # the old store and the new install, so the store would accumulate every
+    # <os>-<arch>-<cpu>-pnpm-store- prefix here would make each save the union
+    # of the old store and the new install, so the store would accumulate every
     # package version ever built and grow without bound. PRs never save, so
     # they do take the prefix fallback and reuse whatever main last stored.
+    #
+    # The key covers runner.arch and inputs.cpu as well as runner.os because
+    # the store's contents are architecture-specific: platform-specific
+    # optional dependencies differ per architecture, and inputs.cpu overrides
+    # which ones pnpm fetches. Keying on runner.os alone lets an x64 and an
+    # arm64 job share one entry, so whichever saves first wins and the other
+    # re-downloads its own packages on every run.
     - name: Restore pnpm cache
       id: cache
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       continue-on-error: true
       with:
         path: ${{ steps.store.outputs.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.cpu || 'default' }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
         # Written as `!= 'main' && <prefix> || ''` rather than the more natural
         # `== 'main' && '' || <prefix>`: in a GitHub expression `a && b || c`
         # falls through to c whenever b is falsy, and '' is falsy, so the
         # natural spelling would hand main the prefix in both branches.
-        restore-keys: ${{ github.ref_name != 'main' && format('{0}-pnpm-store-', runner.os) || '' }}
+        restore-keys: ${{ github.ref_name != 'main' && format('{0}-{1}-{2}-pnpm-store-', runner.os, runner.arch, inputs.cpu || 'default') || '' }}
 
     - name: Set CPU architecture for pnpm
       if: ${{ inputs.cpu }}
@@ -103,4 +110,4 @@ runs:
       continue-on-error: true
       with:
         path: ${{ steps.store.outputs.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.cpu || 'default' }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}


### PR DESCRIPTION
## Problem

The default-branch cache step restored via the `<os>-pnpm-store-` prefix and then saved under the current lockfile hash, so every save was the union of the restored store and the new install. Nothing was ever evicted.

In oxc the Linux store has climbed monotonically for as long as logs are retained:

| Date | Linux store |
|---|---|
| 2026-07-02 | 604 MB |
| 2026-07-15 | 685 MB |
| 2026-07-29 | 772 MB |
| 2026-08-01 | 832 MB |

~7.6 MB/day, +37.7% over 30 days. Job logs 410 before 2026-07-02, so 30 days is the observation limit rather than the age of the problem: the prefix restore-key has been in setup-node since v1.0.0 (adopted by oxc in oxc-project/oxc#11368, 2025-05-29), and this particular accumulation run started at the pnpm `store/v10` → `store/v11` path change (oxc-project/oxc#22224, 2026-05-07), so ~86 days.

It is accumulation, not dependency growth. Commit `dda5636` ("update dependency vite-plus to v0.2.7") was a pure version replacement — 91 additions / 91 deletions, identical lockfile byte size, identical 994 `resolution:` entries — yet the store grew **+12.13 MiB**. Across the 30-day window the lockfile gained 10.7% more packages while the store gained 37.7%.

The cost is not just this cache. `oxc-project/oxc` sits at 10.7 GB across 24 active caches, past the 10 GB threshold, and the nine `*-pnpm-store-*` entries alone are ~5,986 MiB — **~60% of the repo's entire cache budget**. GitHub is LRU-evicting the Rust build caches to make room.

Restore is also 22.4s of the 33.7s this action spends ([job](https://github.com/oxc-project/oxc/actions/runs/30712642560/job/91402811458?pr=25131)): 832 MB, 15.5s download @ ~60MB/s plus 6.8s untar.

## Change

- Restore on the default branch with an exact lockfile match only, so a save can only follow a cold install and the stored tree is exactly what the lockfile needs. PRs keep the prefix fallback, since they never save and so cannot pollute it.
- Split the combined cache action into restore + save, and run the save right after `pnpm install` rather than as a post-job step, so the store survives a later failure in the calling job.
- Key on `runner.arch` and `inputs.cpu` as well as `runner.os`. Architectures were sharing one entry — in oxc, `Test Linux` and `Test Linux ARM64` plus the four Windows NAPI jobs — so whichever saved first won the key and the others silently re-downloaded their own packages on every run.
- Compare against `github.event.repository.default_branch` rather than a hardcoded `'main'`, so repos on `master`/`trunk` get a cache at all.
- Guard the save with `github.event_name != 'pull_request_target'` (see below).

Note that adding architecture to the key changes every key, so the first run after merge is cold everywhere regardless of what we decide below.

## Note for reviewers — cold starts on lockfile bumps

With no prefix fallback on the default branch, every lockfile bump cold-installs. Measured in oxc:

- **~10.5 lockfile changes/week** on main — 136 since 2026-05-01, steady at 7–15/wk
- **16 setup-node jobs per CI run** (11 Linux incl. ARM64, 4 Windows, 1 macOS). They start together, so the entire wave goes cold at once rather than one warming the rest.
- ~22 main CI runs/day → **~7% of setup-node job-runs cold** (~168/week), i.e. **one full-CI cold wave roughly every 16 hours**

So 93% of runs still hit the exact key; the cost is bursty rather than constant. What none of us can quote yet is the per-install price: pre-fix, *every* run hits the prefix fallback, so there is no cold-install datapoint anywhere in the retained window. The first default-branch run on this branch produces it, along with the store's true size.

If we want the warm restore back, two options — **neither is in this PR, and this is the call to make**:

1. **Prune before save.** Restore the prefix fallback, then `pnpm store prune` after `pnpm install`, so the saved store is exactly the current lockfile. Zero cold starts, store stays flat. Costs ~1–3s (the store runs ~38k files/GB, and deleting 20k small files benchmarks at ~1.2s), and depends on `pnpm store prune`'s reference tracking — the v11 store resolves references through symlinks in `store/v11/projects/`, and prune would run after `pnpm install` has registered the current project. Worth asserting with a following `pnpm install --frozen-lockfile --offline`, which fails loudly if prune over-removed instead of silently caching an incomplete store.
2. **Weekly epoch in the key.** Add `date -u +%G-%V` to key and restore-keys. Warm all week, one cold wave per key variant per week, growth capped at ~53 MB of drift, and no coupling to pnpm internals.

## Trade-offs

- **The save no longer captures packages added by later steps.** The post-job upload previously picked up anything a later step added to the store (a second `pnpm install` in a subdir, `pnpm dlx`, e2e task deps). Those are re-downloaded now. That containment is the mechanism that bounds the store, but it is a behavior change.
- **The size win is bounded below, not measured.** `dda5636` proves at least some of the 832 MB is pure accumulation, but oxc also pulls genuinely large prebuilt binaries (`oxlint-tsgolint`, `@napi-rs/cli`, `oxfmt`), so the true floor is unknown until the first cold run reports it.

## Fork PR cache poisoning

`pull_request_target` sets `GITHUB_REF` to the base branch, so `github.ref_name` equals the default branch, and a consumer using the `pull_request_target` + checkout-PR-head pattern would reach the save step holding a fork's lockfile. Cache write scope follows `GITHUB_REF`, so that save lands in the default branch's scope, and every later run picks it up through the prefix fallback.

An earlier revision of this PR asserted that the cache service rejects such writes because only certain triggering events may write the default branch's scope. That is not correct — there is no such event gate — so the save is now guarded with `github.event_name != 'pull_request_target'`, and the comment above the step records the actual reasoning. Fork `pull_request` runs need no guard: they can only write their own merge-ref scope, which no other PR and no branch can restore.

## Not addressed here

- `pnpm/action-setup` costs 6.8s, mostly self-inflicted: the runner image ships pnpm 11.1.1, oxc pins `pnpm@11.17.0`, so the installer runs `npm install` (2.0s) then a full `pnpm self-update` (4.6s), logging `[WARN] Detected a pnpm v10 installation layout at PNPM_HOME`. Worth a separate experiment with `standalone: true`.
- `pnpm store path --silent` costs 0.4s plus step overhead; it could be dropped by writing `npm_config_store_dir` to `$GITHUB_ENV`, at the risk of the cache path silently diverging from the real store.
- Unrelated: `Set CPU architecture for pnpm` appends to `pnpm-workspace.yaml` in the working tree, so any job that sets `cpu` and also runs `git diff --exit-code` will fail on a dirty tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
